### PR TITLE
feat: preserve excel template styles

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,10 @@
 import { FlatCompat } from '@eslint/eslintrc';
+import eslintJs from '@eslint/js';
 
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
+  recommendedConfig: eslintJs.configs.recommended,
+  allConfig: eslintJs.configs.all,
 });
 
 export default [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "exceljs": "^4.4.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/sas/controllers/excel-template.controller.ts
+++ b/src/sas/controllers/excel-template.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { FillExcelTemplateDto } from '@src/shared/dto/fill-excel-template.dto';
+import { ExcelTemplateService } from '../services/excel-template.service';
+import { PrivateBlobService } from '../services/blob-storage/private-blob.service';
+
+/**
+ * Controlador para aplicar datos sobre una plantilla de Excel
+ * y subir el resultado al almacenamiento privado.
+ */
+@ApiTags('Excel Templates')
+@Controller('template')
+export class ExcelTemplateController {
+  constructor(
+    private readonly excelTemplateService: ExcelTemplateService,
+    private readonly privateBlobService: PrivateBlobService,
+  ) {}
+
+  @Post('excel')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Aplica datos a una plantilla de Excel y sube el resultado al contenedor privado',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    description: 'Plantilla y datos a insertar',
+    type: FillExcelTemplateDto,
+  })
+  @UseInterceptors(FileInterceptor('template'))
+  async fillAndUpload(
+    @UploadedFile() template: Express.Multer.File,
+    @Body() body: FillExcelTemplateDto,
+  ): Promise<any> {
+    const rows =
+      typeof body.rows === 'string' ? JSON.parse(body.rows) : body.rows;
+
+    const filledBuffer = await this.excelTemplateService.fillTemplate(
+      template.buffer,
+      rows || [],
+      body.sheetName,
+    );
+
+    const uploadFile: Express.Multer.File = {
+      buffer: filledBuffer,
+      mimetype:
+        template.mimetype ||
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    } as Express.Multer.File;
+
+    const uploadResult = await this.privateBlobService.uploadBlob(
+      body.containerName,
+      body.directory,
+      body.blobName,
+      uploadFile,
+    );
+
+    return {
+      message: 'Template filled and uploaded',
+      ...uploadResult,
+    };
+  }
+}

--- a/src/sas/sas.module.ts
+++ b/src/sas/sas.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { BlobLoggingController } from './controllers/blob-logging.controller';
 import { BlobStorageController } from './controllers/blob-storage.controller';
 import { SasController } from './controllers/sas.controller';
+import { ExcelTemplateController } from './controllers/excel-template.controller';
 import { BlobLoggingService } from './services/blob-logging/blob-logging.service';
 import { LogStrategyFactory } from './services/blob-logging/factories/log-strategy-factory';
 import { CsvLogFormatter } from './services/blob-logging/formatters/csv-formatter';
@@ -10,6 +11,7 @@ import { XlsxLogFormatter } from './services/blob-logging/formatters/xlsx-format
 import { BlobStorageModule } from './services/blob-storage/blob-storage.module';
 import { FileValidationService } from './services/file-validation.service';
 import { SasService } from './services/sas.service';
+import { ExcelTemplateService } from './services/excel-template.service';
 
 /**
  * Módulo principal de SAS (Secure Access Service).
@@ -43,7 +45,12 @@ import { SasService } from './services/sas.service';
  */
 @Module({
   imports: [BlobStorageModule],
-  controllers: [SasController, BlobStorageController, BlobLoggingController],
+  controllers: [
+    SasController,
+    BlobStorageController,
+    BlobLoggingController,
+    ExcelTemplateController,
+  ],
   providers: [
     SasService,
     FileValidationService,
@@ -52,6 +59,7 @@ import { SasService } from './services/sas.service';
     TraditionalLogFormatter,
     CsvLogFormatter,
     XlsxLogFormatter,
+    ExcelTemplateService,
   ],
   exports: [SasService, LogStrategyFactory, BlobLoggingService],
 })

--- a/src/sas/services/excel-template.service.ts
+++ b/src/sas/services/excel-template.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { Workbook } from 'exceljs';
+
+/**
+ * Servicio para aplicar datos sobre una plantilla de Excel.
+ *
+ * Permite recibir un archivo Excel existente (con estilos, colores, etc.)
+ * y agregar filas de datos respetando la estructura original.
+ */
+@Injectable()
+export class ExcelTemplateService {
+  /**
+   * Agrega las filas proporcionadas al final de la hoja indicada de la plantilla.
+   *
+   * @param templateBuffer Buffer del archivo de plantilla.
+   * @param rows           Arreglo de objetos a insertar como filas.
+   * @param sheetName      Nombre de la hoja destino. Si no se proporciona, se usa la primera.
+   * @returns Buffer del archivo Excel resultante.
+   */
+  async fillTemplate(
+    templateBuffer: Buffer,
+    rows: Record<string, any>[],
+    sheetName?: string,
+  ): Promise<Buffer> {
+    const workbook = new Workbook();
+    await workbook.xlsx.load(templateBuffer as any);
+
+    const worksheet = sheetName
+      ? workbook.getWorksheet(sheetName) || workbook.worksheets[0]
+      : workbook.worksheets[0];
+
+    const lastRowNumber = worksheet.lastRow?.number ?? 0;
+    const templateRow = worksheet.getRow(lastRowNumber);
+
+    rows.forEach((rowData) => {
+      const row = worksheet.addRow(Object.values(rowData));
+      templateRow.eachCell({ includeEmpty: true }, (cell, col) => {
+        row.getCell(col).style = { ...cell.style };
+      });
+    });
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
+  }
+}

--- a/src/shared/dto/fill-excel-template.dto.ts
+++ b/src/shared/dto/fill-excel-template.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * DTO para aplicar datos sobre una plantilla de Excel y subir el resultado.
+ */
+export class FillExcelTemplateDto {
+  @ApiProperty({
+    description: 'Nombre del contenedor destino',
+    example: 'reports',
+  })
+  containerName: string;
+
+  @ApiProperty({
+    description: 'Nombre del blob resultante (incluye extensión)',
+    example: 'informe.xlsx',
+  })
+  blobName: string;
+
+  @ApiProperty({
+    description: 'Directorio opcional dentro del contenedor',
+    required: false,
+    example: '2024/enero',
+  })
+  directory?: string;
+
+  @ApiProperty({
+    description: 'Nombre de la hoja donde se insertarán los datos',
+    required: false,
+    example: 'Hoja1',
+  })
+  sheetName?: string;
+
+  @ApiProperty({
+    description: 'Filas a insertar en la plantilla',
+    type: [Object],
+    example: [{ nombre: 'Juan', edad: 30 }],
+  })
+  rows: Record<string, any>[];
+}

--- a/test/sas/services/excel-template.service.test.ts
+++ b/test/sas/services/excel-template.service.test.ts
@@ -1,0 +1,36 @@
+import { Workbook } from 'exceljs';
+import { ExcelTemplateService } from '../../../src/sas/services/excel-template.service';
+
+describe('ExcelTemplateService', () => {
+  const service = new ExcelTemplateService();
+
+  it('should append rows preserving styles', async () => {
+    const workbook = new Workbook();
+    const sheet = workbook.addWorksheet('Sheet1');
+    sheet.addRow(['name', 'age']);
+    const styledRow = sheet.addRow(['Bob', 25]);
+    styledRow.eachCell((cell) => {
+      cell.font = { bold: true };
+      cell.fill = {
+        type: 'pattern',
+        pattern: 'solid',
+        fgColor: { argb: 'FFFF0000' },
+      };
+    });
+    const templateBuffer = Buffer.from(await workbook.xlsx.writeBuffer());
+
+    const resultBuffer = await service.fillTemplate(templateBuffer, [
+      { name: 'Alice', age: 30 },
+    ]);
+
+    const resultWb = new Workbook();
+    await resultWb.xlsx.load(resultBuffer as any);
+    const resultSheet = resultWb.getWorksheet('Sheet1');
+    const newRow = resultSheet.getRow(3);
+
+    expect(newRow.getCell(1).value).toBe('Alice');
+    expect(newRow.getCell(2).value).toBe(30);
+    expect(newRow.getCell(1).font?.bold).toBe(true);
+    expect((newRow.getCell(1).fill as any)?.fgColor?.argb).toBe('FFFF0000');
+  });
+});


### PR DESCRIPTION
## Summary
- support appending rows to Excel templates while preserving styles
- copy cell formatting from the last row to inserted rows
- add ExcelJS-based tests for styled template appends

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a3a5178832c89e4d54e87a4ad87