### PR TITLE
feat: support header-based excel template filling

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "exceljs": "^4.4.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/sas/services/excel-template.service.ts
+++ b/src/sas/services/excel-template.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { Workbook } from 'exceljs';
+import { FillExcelTemplateDto } from '@src/shared/dto/fill-excel-template.dto';
+
+/**
+ * Servicio para llenar una plantilla de Excel usando cabeceras dinámicas.
+ */
+@Injectable()
+export class ExcelTemplateService {
+  /**
+   * Llena la plantilla recibida con los datos proporcionados.
+   * @param dto Parámetros para el llenado del Excel.
+   * @returns Buffer del archivo Excel resultante.
+   */
+  async fillTemplate(dto: FillExcelTemplateDto): Promise<Buffer> {
+    const {
+      template,
+      data,
+      headerRow = 1,
+      startRow = headerRow + 1,
+    } = dto;
+
+    const workbook = new Workbook();
+    await workbook.xlsx.load(template as any);
+    const worksheet = workbook.worksheets[0];
+
+    const headersRow = worksheet.getRow(headerRow);
+    const lastRowNumber = worksheet.lastRow?.number ?? 0;
+    let currentRow = Math.max(startRow, lastRowNumber + 1);
+
+    for (const item of data) {
+      const rowValues: any[] = [];
+
+      headersRow.eachCell({ includeEmpty: false }, (cell, colNumber) => {
+        const key = String(cell.value);
+        rowValues[colNumber] = item[key];
+      });
+
+      const newRow = worksheet.insertRow(currentRow, rowValues);
+
+      const templateRow = worksheet.getRow(startRow - 1);
+      templateRow.eachCell({ includeEmpty: true }, (cell, col) => {
+        newRow.getCell(col).style = { ...cell.style };
+      });
+
+      currentRow++;
+    }
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
+  }
+}

--- a/src/shared/dto/fill-excel-template.dto.ts
+++ b/src/shared/dto/fill-excel-template.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * DTO para llenar plantillas de Excel con datos dinámicos.
+ */
+export class FillExcelTemplateDto {
+  /**
+   * Buffer del archivo de plantilla en formato Excel (.xlsx).
+   */
+  @ApiProperty({ description: 'Plantilla Excel en formato buffer' })
+  template: Buffer;
+
+  /**
+   * Datos a insertar en la plantilla. Las claves deben coincidir con los encabezados.
+   */
+  @ApiProperty({
+    description: 'Datos a insertar en la plantilla',
+    type: 'object',
+    isArray: true,
+  })
+  data: Record<string, any>[];
+
+  /**
+   * Fila donde se encuentran los encabezados que definen las claves.
+   * \@default 1
+   */
+  @ApiProperty({
+    description: 'Fila donde se ubican los encabezados',
+    required: false,
+    type: Number,
+  })
+  headerRow?: number;
+
+  /**
+   * Fila inicial donde deben insertarse los datos.
+   * \@default headerRow + 1
+   */
+  @ApiProperty({
+    description: 'Fila inicial para insertar datos',
+    required: false,
+    type: Number,
+  })
+  startRow?: number;
+}

--- a/test/sas/services/excel-template.service.test.ts
+++ b/test/sas/services/excel-template.service.test.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Workbook } from 'exceljs';
+import { ExcelTemplateService } from '../../../src/sas/services/excel-template.service';
+import { FillExcelTemplateDto } from '../../../src/shared/dto/fill-excel-template.dto';
+
+describe('ExcelTemplateService', () => {
+  let service: ExcelTemplateService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExcelTemplateService],
+    }).compile();
+
+    service = module.get<ExcelTemplateService>(ExcelTemplateService);
+  });
+
+  it('should map columns using headers and preserve styles with multiple header rows', async () => {
+    const workbook = new Workbook();
+    const worksheet = workbook.addWorksheet('Template');
+
+    worksheet.addRow(['Reporte de prueba']);
+    worksheet.addRow(['Grupo A', 'Grupo A', 'Grupo B']);
+    worksheet.addRow(['Name', 'Age', 'City']);
+    worksheet.addRow([]);
+
+    const styleRow = worksheet.getRow(4);
+    styleRow.getCell(1).style = { font: { bold: true, color: { argb: 'FFFF0000' } } };
+    styleRow.getCell(2).style = { numFmt: '#,##0' };
+    styleRow.getCell(3).style = { alignment: { horizontal: 'center' } };
+
+    const templateBuffer = await workbook.xlsx.writeBuffer();
+
+    const dto: FillExcelTemplateDto = {
+      template: Buffer.from(templateBuffer),
+      data: [
+        { Name: 'Alice', Age: 30, City: 'Paris' },
+        { Name: 'Bob', Age: 40, City: 'London' },
+      ],
+      headerRow: 3,
+      startRow: 5,
+    };
+
+    const resultBuffer = await service.fillTemplate(dto);
+    const resultWorkbook = new Workbook();
+    await resultWorkbook.xlsx.load(resultBuffer as any);
+    const ws = resultWorkbook.worksheets[0];
+
+    const firstRow = ws.getRow(5);
+    expect(firstRow.getCell(1).value).toBe('Alice');
+    expect(firstRow.getCell(2).value).toBe(30);
+    expect(firstRow.getCell(3).value).toBe('Paris');
+    expect(firstRow.getCell(1).style.font?.bold).toBe(true);
+    expect(firstRow.getCell(1).style.font?.color?.argb).toBe('FFFF0000');
+    expect(firstRow.getCell(2).style.numFmt).toBe('#,##0');
+    expect(firstRow.getCell(3).style.alignment?.horizontal).toBe('center');
+
+    const secondRow = ws.getRow(6);
+    expect(secondRow.getCell(1).value).toBe('Bob');
+    expect(secondRow.getCell(2).value).toBe(40);
+    expect(secondRow.getCell(3).value).toBe('London');
+    expect(secondRow.getCell(1).style.font?.bold).toBe(true);
+    expect(secondRow.getCell(2).style.numFmt).toBe('#,##0');
+    expect(secondRow.getCell(3).style.alignment?.horizontal).toBe('center');
+  });
+
+  it('should append data when template already contains rows', async () => {
+    const workbook = new Workbook();
+    const worksheet = workbook.addWorksheet('Template');
+
+    worksheet.addRow(['Reporte de prueba']);
+    worksheet.addRow(['Grupo A', 'Grupo A', 'Grupo B']);
+    worksheet.addRow(['Name', 'Age', 'City']);
+    worksheet.addRow([]);
+
+    const styleRow = worksheet.getRow(4);
+    styleRow.getCell(1).style = { font: { bold: true } };
+    styleRow.getCell(2).style = { numFmt: '#,##0' };
+    styleRow.getCell(3).style = { alignment: { horizontal: 'center' } };
+
+    const templateBuffer = await workbook.xlsx.writeBuffer();
+
+    const firstResult = await service.fillTemplate({
+      template: Buffer.from(templateBuffer),
+      data: [
+        { Name: 'Alice', Age: 30, City: 'Paris' },
+        { Name: 'Bob', Age: 40, City: 'London' },
+      ],
+      headerRow: 3,
+      startRow: 5,
+    });
+
+    const secondResult = await service.fillTemplate({
+      template: Buffer.from(firstResult),
+      data: [
+        { Name: 'Carol', Age: 25, City: 'Rome' },
+        { Name: 'Dave', Age: 35, City: 'Madrid' },
+      ],
+      headerRow: 3,
+      startRow: 5,
+    });
+
+    const resultWorkbook = new Workbook();
+    await resultWorkbook.xlsx.load(secondResult as any);
+    const ws = resultWorkbook.worksheets[0];
+
+    const thirdRow = ws.getRow(5);
+    expect(thirdRow.getCell(1).value).toBe('Alice');
+    const fourthRow = ws.getRow(6);
+    expect(fourthRow.getCell(1).value).toBe('Bob');
+    const fifthRow = ws.getRow(7);
+    expect(fifthRow.getCell(1).value).toBe('Carol');
+    expect(fifthRow.getCell(1).style.font?.bold).toBe(true);
+    const sixthRow = ws.getRow(8);
+    expect(sixthRow.getCell(1).value).toBe('Dave');
+    expect(sixthRow.getCell(3).value).toBe('Madrid');
+    expect(sixthRow.getCell(2).style.numFmt).toBe('#,##0');
+    expect(sixthRow.getCell(3).style.alignment?.horizontal).toBe('center');
+  });
+});


### PR DESCRIPTION
## Summary
- add optional `headerRow` and `startRow` to fill Excel template DTO
- implement ExcelTemplateService to map data by headers and copy column styles
- support appending to existing Excel files without overwriting
- cover header-based filling with tests for multi-row templates and append behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa664808dc832cb12b5d9e455eced5